### PR TITLE
Integrate Argument Parsing with Plugin Definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stashhouse"
-version = "0.0.3"
+version = "0.0.4"
 requires-python = ">=3.11"
 authors = [
     {name = "Jayson Fong", email = "jayson.fong@gatech.edu"}
@@ -21,7 +21,9 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Communications :: File Sharing",
+    "Typing :: Typed"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
 
 [project.optional-dependencies]
 ssh = [
-    "stashhouse_ssh>=0.0.1"
+    "stashhouse-ssh>=0.0.5"
+]
+tftp = [
+    "stashhouse-tftp>=0.0.2"
 ]
 
 [project.urls]

--- a/stashhouse/cli.py
+++ b/stashhouse/cli.py
@@ -13,8 +13,7 @@ from . import server, plugin
 
 if TYPE_CHECKING:
     # noinspection PyProtectedMember
-    from importlib.metadata import EntryPoint
-
+    from importlib.metadata import EntryPoint, EntryPoints
 
 LOG_LEVELS: dict[str, int] = {
     "critical": logging.CRITICAL,
@@ -40,7 +39,37 @@ def _log_level(log_level_name: str) -> int:  # noqa
     return LOG_LEVELS.get(log_level_name.lower(), logging.INFO)
 
 
-def _parser(**kwargs) -> argparse.ArgumentParser:
+def _parse_requested_plugins(args: Sequence[str] | None = None) -> Sequence[str]:
+    """
+    Parses the requested plugins to enable.
+
+    Serves to restrict memory usage by preventing
+    the loading of unnecessary plugins entirely.
+
+    Args:
+        args: Sequence of arguments to evaluate.
+
+    Returns:
+        A sequence of plugin names to enable.
+    """
+
+    load_parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        exit_on_error=False, add_help=False
+    )
+
+    # fmt: off
+    load_parser.add_argument(
+        "--enable-plugin", "--enable", "-e",
+        nargs="*", action="extend", dest="plugins", default=[])
+
+    return tuple(load_parser.parse_known_args(args)[0].plugins)
+
+
+def _parser(
+    plugin_definitions: "EntryPoints",
+    desired_plugins: Sequence[str] | None = None,
+    **kwargs,
+) -> argparse.ArgumentParser:
     """
     Creates an argument parser.
 
@@ -48,6 +77,8 @@ def _parser(**kwargs) -> argparse.ArgumentParser:
     may include additional options derived from installed plugins.
 
     Args:
+        plugin_definitions: Plugin definitions to register arguments for.
+        desired_plugins: Sequence of desired plugin names.
         **kwargs: Keyword arguments to pass for parser initialization.
 
     Returns:
@@ -67,27 +98,39 @@ def _parser(**kwargs) -> argparse.ArgumentParser:
                         help="Log level to print to console")
 
     # Plugin Loading
-    plugin_names: list[str] = [entry.name for entry in plugin.find_server_plugins()]
+    plugin_names: list[str] = [
+        entry.name
+        for entry in plugin_definitions
+        if not desired_plugins or entry.name in desired_plugins
+    ]
+
     # fmt: off
     parser.add_argument("--enable-plugin", "--enable", "-e", nargs="+",
                         choices=plugin_names, action="extend", default=[], dest="plugins",
                         help="Plugin names to enable")
 
-    register_plugin: "EntryPoint"
-    for register_plugin in plugin.find_cli_register_plugins():
-        registrar: plugin.PluginArgumentRegistrar = register_plugin.load()
-        registrar(register_plugin.name, parser)
+    plugin_entry: "EntryPoint"
+    for plugin_entry in plugin_definitions:
+        if desired_plugins and plugin_entry.name not in desired_plugins:
+            continue
+
+        registrar: plugin.Plugin = plugin_entry.load()
+        registrar.register_arguments(plugin_entry.name, parser)
 
     return parser
 
 
 def _parse_arguments(
-    args: Sequence[str] | None = None, namespace: argparse.Namespace = None, **kwargs
+    plugin_definitions: "EntryPoints",
+    args: Sequence[str] | None = None,
+    namespace: argparse.Namespace = None,
+    **kwargs,
 ) -> tuple[server.ServerOptions, dict[str, plugin.PluginOptions]]:
     """
     Parse arguments while leveraging installed plugins.
 
     Args:
+        plugin_definitions: Plugin definitions to handle arguments for.
         args: Sequence of arguments to parse.
         namespace: Namespace of options.
         **kwargs: Keyword arguments to pass for parser initialization.
@@ -98,7 +141,10 @@ def _parse_arguments(
         representing plugin names and dictionary (str -> Any) values.
     """
 
-    parser: argparse.ArgumentParser = _parser(**kwargs)
+    desired_plugins: Sequence[str] = _parse_requested_plugins(args)
+    parser: argparse.ArgumentParser = _parser(
+        plugin_definitions, desired_plugins, **kwargs
+    )
     args: argparse.Namespace = parser.parse_args(args, namespace)
 
     # Extract our server options
@@ -113,27 +159,40 @@ def _parse_arguments(
     logging.basicConfig(level=server_options.log_level)
 
     plugin_options: dict[str, plugin.PluginOptions] = {}
-    parser_plugin: "EntryPoint"
-    for parser_plugin in plugin.find_cli_parse_plugins():
-        parser: plugin.PluginArgumentParser = parser_plugin.load()
-        plugin_options[parser_plugin.name] = parser(parser_plugin.name, args)
+    plugin_entry: "EntryPoint"
+    for plugin_entry in plugin_definitions:
+        if desired_plugins and plugin_entry.name not in desired_plugins:
+            continue
+
+        parser: plugin.Plugin = plugin_entry.load()
+        plugin_options[plugin_entry.name] = parser.derive_options(
+            plugin_entry.name, args
+        )
 
     return server_options, plugin_options
 
 
 def main(
-    args: Sequence[str] | None = None, namespace: argparse.Namespace = None, **kwargs
+    plugin_definitions: "EntryPoints | None" = None,
+    args: Sequence[str] | None = None,
+    namespace: argparse.Namespace = None,
+    **kwargs,
 ) -> None:
     """
     Parse arguments and start the server accordingly.
 
     Args:
+        plugin_definitions: Plugin definitions to handle arguments for.
         args: Sequence of arguments to parse.
         namespace: Namespace of options.
         **kwargs: Keyword arguments to pass for parser initialization.
     """
+    if plugin_definitions is None:
+        plugin_definitions: "EntryPoints" = plugin.find_plugins()
 
-    options, plugin_options = _parse_arguments(args, namespace, **kwargs)
+    options, plugin_options = _parse_arguments(
+        plugin_definitions, args, namespace, **kwargs
+    )
     with server.Server(options, **plugin_options) as stashhouse:
         try:
             stashhouse.join()

--- a/stashhouse/plugin.py
+++ b/stashhouse/plugin.py
@@ -10,11 +10,8 @@ from typing import (
     Protocol,
     runtime_checkable,
     TypedDict,
-    NotRequired,
     Unpack,
     TYPE_CHECKING,
-    Generator,
-    Callable,
 )
 
 if TYPE_CHECKING:
@@ -28,16 +25,12 @@ class PluginOptions(TypedDict, total=False):
     """
     Plugin options.
 
-    A plugin may optionally offer the "enable" option
-    to designate whether a plugin should be enabled or not.
-    If a plugin offers it, it must be a boolean. Plugins
-    may offer additional plugin options.
+    This is provided for future expansion, though
+    there currently does not exist any mandates
+    on the plugin option definitions.
     """
 
-    enable: NotRequired[bool]
 
-
-# pylint: disable=too-few-public-methods
 @runtime_checkable
 class Plugin(Protocol):
     """
@@ -67,53 +60,46 @@ class Plugin(Protocol):
         Start the plugin.
         """
 
+    @classmethod
+    def register_arguments(
+        cls, plugin_name: str, parser: argparse.ArgumentParser
+    ) -> None:
+        """
+        Adds arguments to a parser for a plugin.
 
-PluginArgumentRegistrar = Callable[[str, argparse.ArgumentParser], None]
-PluginArgumentParser = Callable[[str, argparse.Namespace], PluginOptions]
+        Args:
+            plugin_name: The plugin name.
+            parser: An argument parser.
+        """
+
+    @classmethod
+    def derive_options(
+        cls, plugin_name: str, args: argparse.Namespace
+    ) -> PluginOptions:
+        """
+        Given a namespace, extracts the plugin's options.
+
+        Args:
+            plugin_name: The plugin name.
+            args: An argument parser.
+
+        Returns:
+            A dictionary of values for the plugin.
+        """
+
 
 logger = logging.getLogger(__name__)
 
 
-def find_server_plugins() -> Generator["EntryPoint", None, None]:
+def find_plugins() -> "EntryPoints":
     """
-    Identifies server plugin entry points.
+    Identifies plugin definitions based on entry points.
 
-    Yields:
-        An entry point pointing to instances of Plugin.
-    """
-
-    yield from entry_points(group="stashhouse.plugins.server")
-
-
-def find_cli_register_plugins() -> "EntryPoints":
-    """
-    Identifies CLI register plugins.
-
-    A PluginArgumentRegistrar represents a callable that accepts
-    a string plugin name and an argument parser with the
-    expectation that it will register arguments as required to
-    the provided argument parser.
-
-    Yields:
-        An entry point pointing to a PluginArgumentRegistrar.
+    Returns:
+        Entry points of plugins.
     """
 
-    return entry_points(group="stashhouse.plugins.cli.register")
-
-
-def find_cli_parse_plugins() -> "EntryPoints":
-    """
-    Identifies CLI parser plugins.
-
-    A PluginArgumentParser represents a callable that accepts
-    a string plugin name and an argparse.Namespace with
-    the expectation that it will return a dictionary of
-    plugin options extracted from the namespace.
-
-    Yields:
-        An entry point pointing to a PluginArgumentParser.
-    """
-    return entry_points(group="stashhouse.plugins.cli.parse")
+    return entry_points(group="stashhouse.plugin")
 
 
 def _run_server_plugin(
@@ -159,4 +145,4 @@ def run_server_plugin(*args, **kwargs) -> multiprocessing.Process:
     return multiprocessing.Process(target=_run_server_plugin, args=args, kwargs=kwargs)
 
 
-__all__ = ("PluginOptions", "Plugin", "find_server_plugins", "run_server_plugin")
+__all__ = ("PluginOptions", "Plugin", "find_plugins", "run_server_plugin")

--- a/stashhouse/server.py
+++ b/stashhouse/server.py
@@ -17,7 +17,7 @@ from . import plugin
 
 if TYPE_CHECKING:
     # noinspection PyProtectedMember
-    from importlib.metadata import EntryPoint
+    from importlib.metadata import EntryPoint, EntryPoints
 
 logger = logging.getLogger(__name__)
 
@@ -65,15 +65,22 @@ class Server:
         plugin_options: Options to apply at the plugin level.
         _plugins: An exit stack to clean up the server.
         _processes: List of all processes launched.
+        _plugin_definitions: Plugin definitions to evaluate.
     """
 
-    def __init__(self, options: ServerOptions | None = None, **plugin_options):
+    def __init__(
+        self,
+        options: ServerOptions | None = None,
+        plugins: "EntryPoints | None" = None,
+        **plugin_options,
+    ):
         """
         Initializes the server.
 
         Args:
-        options: Server options to apply globally.
-        plugin_options: Options to apply at the plugin level.
+            options: Server options to apply globally.
+            plugins: Plugin definitions to evaluate.
+            plugin_options: Options to apply at the plugin level.
         """
 
         self.options = options
@@ -84,6 +91,22 @@ class Server:
         self.plugin_options = plugin_options
         self._plugins: contextlib.ExitStack = contextlib.ExitStack()
         self._processes: list[multiprocessing.Process] = []
+
+        self._plugin_definitions = plugins
+        if self._plugin_definitions is None:
+            self._plugin_definitions = self._find_plugin_definitions()
+
+    def _find_plugin_definitions(self) -> "EntryPoints":
+        """
+        Identifies plugin definitions.
+
+        Only called if plugin definitions are not provided initially.
+
+        Returns:
+            Plugin definitions to evaluate.
+        """
+
+        return plugin.find_plugins()
 
     def _load_plugin(self, plugin_entry: "EntryPoint") -> None:
         """
@@ -122,14 +145,13 @@ class Server:
         """
         Start the server and all enabled plugins.
 
-        Identifies all plugins through finding all entry
-        points in the group "stashhouse.plugins.server".
-        It is expected that the value maps to a class
-        conforming to the plugin.Plugin protocol.
+        Loops through the plugin definitions and attempts
+        to load them, if enabled. If an error occurs during
+        this process, the full server will halt.
         """
 
         try:
-            for plugin_entry in plugin.find_server_plugins():
+            for plugin_entry in self._plugin_definitions:
                 if plugin_entry.name not in self.options.plugins:
                     continue
 


### PR DESCRIPTION
Modifies the plugin protocol to include class methods required for argument parsing.

While the original version included additional entry points to account for this while seeking to optimize for memory, it was clunky and repetitive. While this update imports more modules into the main process, it also makes it such that when plugins are defined, the plugins loaded are restricted to those defined.